### PR TITLE
fix an anchor tag

### DIFF
--- a/src/_generate/authors.njk
+++ b/src/_generate/authors.njk
@@ -10,7 +10,7 @@ eleventyComputed:
   title: "{{ contributor.name }} の記事"
 ---
 
-<img width="60" height="60" style="margin-left: 0.2rem" alt="{{ contributor.name }}" src="https://github.com/{{ contributor.github }}.png?size=40" /></a>
+<a href="https://github.com/{{ contributor.github }}"><img width="60" height="60" style="margin-left: 0.2rem" alt="{{ contributor.name }}" src="https://github.com/{{ contributor.github }}.png?size=40" /></a>
 
 {% set pages = pagination.pages | byAuthor(contributor.name) %}
 {% set hrefs = pagination.hrefs | selectAuthor(contributor.name) %}


### PR DESCRIPTION
Authors ページのアンカータグに開始がなく、終了のみだったため、開始タグを追加しました