### PR TITLE
画面右の目次をスクロールに追従してハイライトする機能を実装してみた。

### DIFF
--- a/components/preact/hooks.js
+++ b/components/preact/hooks.js
@@ -1,0 +1,51 @@
+import { useEffect, useState, useRef } from 'react';
+
+export function useHeadsObserver() {
+    const [activeId, setActiveId] = useState('');
+    const observer = useRef();
+
+    useEffect(() => {
+        const handleObserver = (entries) => {
+            if (!entries) {
+                return;
+            }
+
+            // intersectしているヘッダーがあれば、目次内のそのヘッダーをハイライト対象とする。
+            let activeId = "";
+            entries.find((entry) => {
+                if (entry?.isIntersecting) {
+                    activeId = entry.target.id;
+                }
+            });
+
+            // FIXME もっとスマートな方針ありそう
+            // interctしているヘッダーがない場合、viewport上端との差（絶対値）が最も近いヘッダーをハイライト対象とする。
+            // IntersectionObserverEntry.isIntersectingだけの判定だと、リロード時にintersectしているものが一つもない場合にハイライトされない。
+            // ここでの判定基準は以下。
+            // 1. viewport内にヘッダーが見えていれば、viewportの上端（＝画面の一番上側にあるもの）をハイライト対象とする。
+            // 2. viewport内にいずれのヘッダーも見えていない場合、上方向にスクロールした場合に現れる（＝現時点では隠れている）最も近いヘッダーをハイライト対象とする。
+            if (!activeId) {
+                let activeEntry = [...entries].reduce((v1, v2) => {
+                    return Math.abs(v1?.boundingClientRect.top) < Math.abs(v2?.boundingClientRect.top) ? v1 : v2;
+                });
+                activeId = activeEntry.target.id;
+            }
+
+            setActiveId(activeId)
+        };
+
+        // viewportの上部10%の領域と監視対象のヘッダーがintersectしたらコールバック処理
+        observer.current = new IntersectionObserver(handleObserver, { rootMargin: "0% 0% -95% 0%" });
+
+        const elements = document.querySelectorAll('h1, h2');
+        [...elements].slice(1).forEach((elem) => {
+            observer.current.observe(elem);
+        });
+
+        return () => {
+            observer.current?.disconnect();
+        };
+    }, []);
+
+    return { activeId }
+}

--- a/components/preact/hooks.js
+++ b/components/preact/hooks.js
@@ -11,12 +11,8 @@ export function useHeadsObserver() {
             }
 
             // intersectしているヘッダーがあれば、目次内のそのヘッダーをハイライト対象とする。
-            let activeId = "";
-            entries.find((entry) => {
-                if (entry?.isIntersecting) {
-                    activeId = entry.target.id;
-                }
-            });
+            const entry = entries.find(entry => entry.isIntersecting);
+            let activeId = entry?.target.id;
 
             // FIXME もっとスマートな方針ありそう
             // interctしているヘッダーがない場合、viewport上端との差（絶対値）が最も近いヘッダーをハイライト対象とする。
@@ -25,10 +21,10 @@ export function useHeadsObserver() {
             // 1. viewport内にヘッダーが見えていれば、viewportの上端（＝画面の一番上側にあるもの）をハイライト対象とする。
             // 2. viewport内にいずれのヘッダーも見えていない場合、上方向にスクロールした場合に現れる（＝現時点では隠れている）最も近いヘッダーをハイライト対象とする。
             if (!activeId) {
-                let activeEntry = [...entries].reduce((v1, v2) => {
+                const activeEntry = [...entries].reduce((v1, v2) => {
                     return Math.abs(v1?.boundingClientRect.top) < Math.abs(v2?.boundingClientRect.top) ? v1 : v2;
                 });
-                activeId = activeEntry.target.id;
+                activeId = activeEntry?.target.id;
             }
 
             setActiveId(activeId)

--- a/components/preact/hooks.js
+++ b/components/preact/hooks.js
@@ -34,7 +34,7 @@ export function useHeadsObserver() {
             setActiveId(activeId)
         };
 
-        // viewportの上部10%の領域と監視対象のヘッダーがintersectしたらコールバック処理
+        // viewportの上部5%の領域と監視対象のヘッダーがintersectしたらコールバック処理
         observer.current = new IntersectionObserver(handleObserver, { rootMargin: "0% 0% -95% 0%" });
 
         const elements = document.querySelectorAll('h1, h2');

--- a/components/preact/toc.js
+++ b/components/preact/toc.js
@@ -2,6 +2,7 @@ import { html } from "htm/preact";
 import render from "preact-render-to-string";
 import { hydrate as preactHydrate } from "preact";
 import { useEffect, useState } from "preact/hooks";
+import { useHeadsObserver } from './hooks';
 
 function slugify(target) {
   return target
@@ -13,6 +14,8 @@ function slugify(target) {
 
 function Toc() {
   const [data, setData] = useState([]);
+  const {activeId} = useHeadsObserver();
+
   useEffect(() => {
     const tags = document.querySelectorAll("h1,h2");
     const newData = [...tags].slice(1)
@@ -49,10 +52,16 @@ function Toc() {
       ${nodes.map((node) => {
       if ("children" in node) {
         return html`
-          <li><a href="${node.anchor}">${node.text}</a>${makeList(node.children)}</li>`;
+          <li><a
+            href="${node.anchor}"
+            class="${slugify(`${activeId}`) === slugify(`${node.text}`) ? 'toc-current-header' : ''}"
+          >${node.text}</a>${makeList(node.children)}</li>`;
       } else {
         return html`
-          <li><a href="${node.anchor}">${node.text}</a></li>`;
+          <li><a
+            href="${node.anchor}"
+            class="${slugify(`${activeId}`) === slugify(`${node.text}`) ? 'toc-current-header' : ''}"
+          >${node.text}</a></li>`;
       }
     })}
     </ul>`;

--- a/src/sass/_post.scss
+++ b/src/sass/_post.scss
@@ -1,5 +1,7 @@
 @import "typography";
 
+$toc-highlight-color: #ebe0fb;
+
 .post {
   display: flex;
   flex-direction: column;
@@ -73,6 +75,14 @@
     li {
       list-style-type: none;
       font-size: 0.8rem;
+
+      a {
+        display: block;
+        width: 65%;
+
+        &:hover { background-color: desaturate($toc-highlight-color, 80%); }
+        &.toc-current-header { background-color: $toc-highlight-color; }
+      }
     }
     position: fixed;
     width: calc((100vw - 80ch)/2 - 3rem);


### PR DESCRIPTION
記事じゃなくて恐縮ですが、目次のハイライト機能を実装してみたのでPR出します。
Reactはほとんど知らないですが、勉強にと思ってやってみました。
ご確認をお願いいたします。

## 実装したもの

画面右の目次を、スクロールに追従してハイライトさせる機能。

## 仕様

[IntersectionObserver API](https://developer.mozilla.org/ja/docs/Web/API/Intersection_Observer_API)を使いました。

簡単にまとめると

- h1、h2要素をターゲットとし、viewport上部5%の領域（以下、監視領域と記載）内を監視する。
- ターゲットが監視領域と交差（intersect）したら、対応する目次の見出しをハイライトする。
- 監視領域にターゲットがない場合、viewport上端（画面最上部）から最も近い見出しをハイライトする。ただし、
  - （監視領域内にはないけど）viewport内にヘッダーが存在していれば、その最上部のものをハイライトする。
  - viewport内にいずれの見出しも存在しない場合、上方向に最も近い見出しをハイライトする。

Qiitaの目次の挙動を参考にして、だいたいそれっぽい動きはしてると思います。

## 参考

[Create a table of contents with highlighting in React](https://blog.logrocket.com/create-table-contents-highlighting-react/)