### PR TITLE
feat: display external collaborators

### DIFF
--- a/src/_components/Calendar.tsx
+++ b/src/_components/Calendar.tsx
@@ -3,8 +3,13 @@ const Entry = (
 ) => {
   const authorImageURL = githubUser
     ? `https://github.com/${githubUser}.png`
-    : null;
-  const authorLink = author ? `/authors/${author}` : null;
+    : '/img/android-chrome-192x192.png'; // GitHub アカウントがない場合のデフォルト画像
+  // _ で始まる author はリンクを生成しない
+  const authorLink = author && !author.startsWith('_') ? `/authors/${author}` : null;
+  let authorName = author;
+  if (author && author.startsWith('_')) {
+    authorName = author.slice(1);
+  }
   return (
     <div
       style={{
@@ -17,7 +22,7 @@ const Entry = (
       <p style={{ textAlign: "center" }}>{dayOfWeek}</p>
       <p style={{ textAlign: "center" }}>{date}</p>
       <p style={{ fontSize: "14px" }}>
-        {authorImageURL &&
+        {author &&
           (
             <a href={authorLink}>
               <img
@@ -32,7 +37,8 @@ const Entry = (
               />
             </a>
           )}
-        {author ? <a href={authorLink}>{author}</a> : author}
+        {authorLink ? <a href={authorLink}>{authorName}</a> : null}
+        {!authorLink && authorName ? authorName : null}
       </p>
       <p style={{ textAlign: "left", fontSize: "14px" }}>
         {url ? <a href={url}>{title}</a> : title}

--- a/src/_components/Calendar.tsx
+++ b/src/_components/Calendar.tsx
@@ -1,15 +1,11 @@
 const Entry = (
-  { dayOfWeek, date, author, githubUser, title, url }: Lume.Data,
+  { dayOfWeek, date, author, nonContrib ,githubUser, title, url }: Lume.Data,
 ) => {
   const authorImageURL = githubUser
     ? `https://github.com/${githubUser}.png`
     : '/img/android-chrome-192x192.png'; // GitHub アカウントがない場合のデフォルト画像
-  // _ で始まる author はリンクを生成しない
-  const authorLink = author && !author.startsWith('_') ? `/authors/${author}` : null;
-  let authorName = author;
-  if (author && author.startsWith('_')) {
-    authorName = author.slice(1);
-  }
+  // contributors.json に未登録の author はリンクを生成しない
+  const authorLink = author && !nonContrib ? `/authors/${author}` : null;
   return (
     <div
       style={{
@@ -37,8 +33,8 @@ const Entry = (
               />
             </a>
           )}
-        {authorLink ? <a href={authorLink}>{authorName}</a> : null}
-        {!authorLink && authorName ? authorName : null}
+        {authorLink ? <a href={authorLink}>{author}</a> : null}
+        {!authorLink && author ? author : null}
       </p>
       <p style={{ textAlign: "left", fontSize: "14px" }}>
         {url ? <a href={url}>{title}</a> : title}
@@ -78,6 +74,7 @@ export default ({ year, weekend, events }: Lume.Data) => {
             dayOfWeek={entry.dayOfWeek}
             date={entry.date}
             author={entry.author}
+            nonContrib={entry.nonContrib}
             githubUser={entry.githubUser}
             title={entry.title}
             url={entry.url}

--- a/src/_data/events/advent/2024.json
+++ b/src/_data/events/advent/2024.json
@@ -115,8 +115,7 @@
     },
     {
       "date": "23",
-      "author": "shigeki-shoji",
-      "githubUser": "edward-mamezou",
+      "author": "_naoko-nakayama",
       "title": "何か書きます"
     },
     {
@@ -127,7 +126,7 @@
     },
     {
       "date": "25",
-      "author": "takashi-egawa",
+      "author": "_takashi-egawa",
       "githubUser": "egglang",
       "title": "なんか書きます"
     }

--- a/src/_data/events/advent/2024.json
+++ b/src/_data/events/advent/2024.json
@@ -115,7 +115,8 @@
     },
     {
       "date": "23",
-      "author": "_naoko-nakayama",
+      "author": "naoko-nakayama",
+      "nonContrib": true,
       "title": "何か書きます"
     },
     {
@@ -126,7 +127,8 @@
     },
     {
       "date": "25",
-      "author": "_takashi-egawa",
+      "author": "takashi-egawa",
+      "nonContrib": true,
       "githubUser": "egglang",
       "title": "なんか書きます"
     }


### PR DESCRIPTION
- 外部コラボレータをカレンダーに表示する時、authors のリンクを表示しないように変更
- 外部コラボレータが GItHub アカウントを持っていない場合デフォルトのアイコンを表示するよう変更