### PR TITLE
Fix font URL in edge function

### DIFF
--- a/netlify/edge-functions/og.tsx
+++ b/netlify/edge-functions/og.tsx
@@ -1,7 +1,7 @@
 import React from 'https://esm.sh/react@18.2.0';
 import { ImageResponse } from 'https://deno.land/x/og_edge@0.0.6/mod.ts';
 
-const font = fetch('https:/developer.mamezou-tech.com/fonts/KosugiMaru-Regular.ttf')
+const font = fetch('https://developer.mamezou-tech.com/fonts/KosugiMaru-Regular.ttf')
   .then((res) => res.arrayBuffer());
 export default async function handler(request: Request) {
   const fontData = (await font);


### PR DESCRIPTION
## Summary
- correct font fetch URL in `og.tsx`

## Testing
- `deno task lint` *(fails: deno: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fc4da8fbc8332a6d87a8be179a54d