### PR TITLE
fix: stabilize weekly ranking GA query

### DIFF
--- a/scripts/bin/weekly-ranking.ts
+++ b/scripts/bin/weekly-ranking.ts
@@ -14,6 +14,7 @@ const analyticsDataClient = new BetaAnalyticsDataClient({
 const now = DateTime.now();
 const yesterday = now.minus({ days: 1 });
 const oneWeekAgo = now.minus({ weeks: 1 });
+const siteHost = "developer.mamezou-tech.com";
 
 type Rank = {
   title: string;
@@ -36,17 +37,17 @@ async function runReport(reportFile: string) {
         name: "pageTitle",
       },
       {
-        name: "fullPageUrl",
+        name: "pagePath",
       },
     ],
     metrics: [
       {
-        name: "eventCount",
+        name: "screenPageViews",
       },
     ],
     orderBys: [
       {
-        metric: { name: "eventCount" },
+        metric: { metricName: "screenPageViews" },
         desc: true,
       },
     ],
@@ -55,25 +56,25 @@ async function runReport(reportFile: string) {
         expressions: [
           {
             filter: {
-              fieldName: "eventName",
-              stringFilter: { value: "page_view"},
+              fieldName: "hostName",
+              stringFilter: { value: siteHost },
             },
           },
           {
             notExpression: {
               filter: {
-                fieldName: "fullPageUrl",
+                fieldName: "pagePath",
                 stringFilter: {
                   matchType: "EXACT",
-                  value: "developer.mamezou-tech.com/",
+                  value: "/",
                 },
               },
-            },            
-          }
+            },
+          },
         ],
       },
     },
-    limit: 20,
+    limit: 10,
   }, {
     timeout: 60000,
     retry: {
@@ -90,18 +91,18 @@ async function runReport(reportFile: string) {
     },
   });
 
-  const articles: Rank[] = response.rows!
-    .slice(0, 10)
+  const rows = response.rows ?? [];
+  const articles: Rank[] = rows
     .map((row) => {
-      const [title, url] = row.dimensionValues!.map((v) => v.value);
+      const [title, path] = row.dimensionValues!.map((v) => v.value);
       const pv = +(row.metricValues![0].value || 0);
       return {
         title: title!.replace(" | 豆蔵デベロッパーサイト", "").replace(
           " | Mamezou Developer Portal",
           "",
         ),
-        path: url!.replace("developer.mamezou-tech.com", ""),
-        url: url || "",
+        path: path || "",
+        url: `https://${siteHost}${path || ""}`,
         pv,
       };
     });
@@ -141,7 +142,7 @@ async function notifyToSlack(ranks: Rank[]) {
         text: {
           type: "mrkdwn",
           text: ranks.map((a, i) =>
-            `${i + 1}. <https://${a.url}|${a.title}> : ${a.pv}`
+            `${i + 1}. <${a.url}|${a.title}> : ${a.pv}`
           ).join("\n"),
         },
       },

--- a/src/_data/pv.json
+++ b/src/_data/pv.json
@@ -1,10 +1,6 @@
 {
   "ranking": [
     {
-      "title": "ソーラーLEDドライバー「YX8018」を使ってみる",
-      "url": "/blogs/2024/03/31/solar-garden-light-by-joule-thief-circuit/"
-    },
-    {
       "title": "【新人さん向け】A5:SQL Mk-2のおすすめ設定と使い方",
       "url": "/blogs/2024/06/08/a5m2_settings/"
     },
@@ -17,28 +13,32 @@
       "url": "/blogs/2023/03/22/use-excalidraw/"
     },
     {
-      "title": "初心者も挑戦！3D Gaussian Splattingで作るリアル3Dモデリング入門",
-      "url": "/robotics/3dgs/3dgs-beginners-guide/"
-    },
-    {
-      "title": "AWS Generative AI Developer 合格とW全冠達成記",
-      "url": "/blogs/2026/04/20/aws_certified_generative_ai_developer/"
-    },
-    {
-      "title": "最先端ロボ×AIで遊ぼう！LeRobotとSO-101でマルチモーダルAIを体験＆環境構築ガイド",
-      "url": "/robotics/lerobot/lerobot_introduction/"
-    },
-    {
-      "title": "Microsoft Presidio: 個人情報保護に特化したオープンソースツール",
-      "url": "/blogs/2025/01/04/presidio-intro/"
+      "title": "TwinCATで始めるソフトウェアPLC開発（その1：開発環境構築編）",
+      "url": "/robotics/twincat/introduction/twincat-introduction/"
     },
     {
       "title": "クラウドに頼らないAI体験：LM Studioで始めるローカルLLM入門（Gemma 3）",
       "url": "/blogs/2025/09/21/gemma_on_lm_studio/"
     },
     {
+      "title": "2025年版！VS Code で Java 開発環境を構築する",
+      "url": "/blogs/2025/10/13/write-java-with-vscode-2025/"
+    },
+    {
+      "title": "rclone - CLI で クラウドストレージのファイルを同期する (Google Drive 編)",
+      "url": "/blogs/2025/07/23/sync-google-drive-files-with-rclone/"
+    },
+    {
       "title": "【新人さん向け】Java開発で最初に確認しておきたいEclipse便利設定ガイド",
       "url": "/blogs/2025/04/13/eclipse-settings-for-newcomer/"
+    },
+    {
+      "title": "直感が理性に大反抗！「モンティ・ホール問題」",
+      "url": "/blogs/2022/07/04/monty-hall-problem/"
+    },
+    {
+      "title": "基本から理解するJWTとJWT認証の仕組み",
+      "url": "/blogs/2022/12/08/jwt-auth/"
     }
   ]
 }

--- a/src/_data/pv.json
+++ b/src/_data/pv.json
@@ -1,6 +1,10 @@
 {
   "ranking": [
     {
+      "title": "ソーラーLEDドライバー「YX8018」を使ってみる",
+      "url": "/blogs/2024/03/31/solar-garden-light-by-joule-thief-circuit/"
+    },
+    {
       "title": "【新人さん向け】A5:SQL Mk-2のおすすめ設定と使い方",
       "url": "/blogs/2024/06/08/a5m2_settings/"
     },
@@ -13,32 +17,28 @@
       "url": "/blogs/2023/03/22/use-excalidraw/"
     },
     {
-      "title": "TwinCATで始めるソフトウェアPLC開発（その1：開発環境構築編）",
-      "url": "/robotics/twincat/introduction/twincat-introduction/"
+      "title": "初心者も挑戦！3D Gaussian Splattingで作るリアル3Dモデリング入門",
+      "url": "/robotics/3dgs/3dgs-beginners-guide/"
+    },
+    {
+      "title": "AWS Generative AI Developer 合格とW全冠達成記",
+      "url": "/blogs/2026/04/20/aws_certified_generative_ai_developer/"
+    },
+    {
+      "title": "最先端ロボ×AIで遊ぼう！LeRobotとSO-101でマルチモーダルAIを体験＆環境構築ガイド",
+      "url": "/robotics/lerobot/lerobot_introduction/"
+    },
+    {
+      "title": "Microsoft Presidio: 個人情報保護に特化したオープンソースツール",
+      "url": "/blogs/2025/01/04/presidio-intro/"
     },
     {
       "title": "クラウドに頼らないAI体験：LM Studioで始めるローカルLLM入門（Gemma 3）",
       "url": "/blogs/2025/09/21/gemma_on_lm_studio/"
     },
     {
-      "title": "2025年版！VS Code で Java 開発環境を構築する",
-      "url": "/blogs/2025/10/13/write-java-with-vscode-2025/"
-    },
-    {
-      "title": "rclone - CLI で クラウドストレージのファイルを同期する (Google Drive 編)",
-      "url": "/blogs/2025/07/23/sync-google-drive-files-with-rclone/"
-    },
-    {
       "title": "【新人さん向け】Java開発で最初に確認しておきたいEclipse便利設定ガイド",
       "url": "/blogs/2025/04/13/eclipse-settings-for-newcomer/"
-    },
-    {
-      "title": "直感が理性に大反抗！「モンティ・ホール問題」",
-      "url": "/blogs/2022/07/04/monty-hall-problem/"
-    },
-    {
-      "title": "基本から理解するJWTとJWT認証の仕組み",
-      "url": "/blogs/2022/12/08/jwt-auth/"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- stabilize weekly GA ranking query to avoid timeout/failure
- switch to GA page view metric/dimensions suitable for ranking
- fix invalid orderBy payload for GA Data API REST

## Details
- use `pagePath` + `screenPageViews`
- filter by `hostName=developer.mamezou-tech.com`
- exclude top page `/`
- reduce query limit to 10
- normalize generated URL and fix Slack link format

## Validation
- deno check scripts/bin/weekly-ranking.ts
