### PR TITLE
ci: update actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/generate-weekly-ranking.yml
+++ b/.github/workflows/generate-weekly-ranking.yml
@@ -21,7 +21,7 @@ jobs:
           deno-version: v2.x
 
       - name: configure google credentials
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ vars.GCP_IDENTITY_PROVIDER }}
           service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
@@ -37,7 +37,7 @@ jobs:
           deno task generate:ranking
 
       - name: Commit and Create Pull request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           commit-message: "feat: Add PV ranking report"
           add-paths: "src/_data"

--- a/.github/workflows/generate-weekly-ranking.yml
+++ b/.github/workflows/generate-weekly-ranking.yml
@@ -37,6 +37,7 @@ jobs:
           deno task generate:ranking
 
       - name: Commit and Create Pull request
+        if: github.ref == 'refs/heads/main'
         uses: peter-evans/create-pull-request@v8
         with:
           commit-message: "feat: Add PV ranking report"


### PR DESCRIPTION
## Summary
- update GitHub Actions versions to Node.js 24 compatible

## Changes
- `google-github-actions/auth@v2` → `v3`
- `peter-evans/create-pull-request@v6` → `v8`

## Background
Node.js 20 actions will be deprecated on June 2nd, 2026 and removed on September 16th, 2026.
