### PR TITLE
chore: 画像生成プロンプトで画像内テキストを英語指定

### DIFF
--- a/scripts/bin/generate-column.ts
+++ b/scripts/bin/generate-column.ts
@@ -234,18 +234,21 @@ async function generateImage(
   { title, details }: { title: string; details: string },
   date: string,
 ) {
+  const imageTextRule =
+    "If you include any text in the illustration, render all visible text in natural English only. Do not render Japanese or pseudo-Japanese glyphs.";
   const promptSuggestion = await openai.responses.create({
     model: "gpt-4.1-mini",
     input:
       `Create an anime-inspired, cartoon-style illustration focused on the theme: '${title}'. 
 Incorporate key elements from the following details: '${details}'. 
-Include both characters and objects whenever possible, using bright colors and a fun, playful atmosphere.`,
+Include both characters and objects whenever possible, using bright colors and a fun, playful atmosphere.
+${imageTextRule}`,
   });
   console.log(promptSuggestion.output_text);
 
   const response = await openai.images.generate({
     prompt: promptSuggestion.output_text ||
-      `${title}\n${details}`,
+      `${title}\n${details}\n${imageTextRule}`,
     model: "gpt-image-1",
     size: "1024x1024",
     quality: "medium",


### PR DESCRIPTION
## 概要
- gpt-image-1 で画像内の日本語風テキストが崩れる問題に対応
- 画像生成プロンプトに『画像内テキストは英語のみ』の制約を追加

## 変更内容
- scripts/bin/generate-column.ts
  - generateImage 内で英語テキスト制約文言を追加
  - プロンプト生成 (gpt-4.1-mini) とフォールバックプロンプト双方に同制約を適用

## 確認観点
- 明日以降の定期生成で、画像内テキストが英語として自然に表示されること
